### PR TITLE
Include link to changelog in "failure: bounds" messages

### DIFF
--- a/src/Curator/Snapshot.hs
+++ b/src/Curator/Snapshot.hs
@@ -211,6 +211,7 @@ pkgBoundsError dep maintainers mdepVer isBoot users =
   where
     showDepVer | Just version <- mdepVer =
                    T.concat [ display dep , "-" , display version
+                            , displayChangelog dep version
                             , displayMaintainers maintainers
                             , " is out of bounds for:"
                             ]
@@ -220,6 +221,12 @@ pkgBoundsError dep maintainers mdepVer isBoot users =
                             , if isBoot then ", GHC boot library" else ""
                             , ") depended on by:"
                             ]
+
+    displayChangelog pkgName version = T.concat
+            [ " ([changelog](http://hackage.haskell.org/package/"
+            , display dep, "-", display version
+            , "/changelog))"
+            ]
 
     displayMaintainers ms | Set.null ms = ""
                           | otherwise = T.concat [" (", T.intercalate ", " (Set.toList ms), ")"]


### PR DESCRIPTION
**Warning: untested!**

This changes messages like

> neat-interpolation-0.4 (\<name> \<email> \<github-username>) is out of bounds for:

to

> neat-interpolation-0.4 ([changelog](http://hackage.haskell.org/package/neat-interpolation-0.4/changelog)) (\<name> \<email> \<github-username>) is out of bounds for:

Note that not all packages have changelogs, in which case users land on a page like [this one](http://hackage.haskell.org/package/present-4.1.0/changelog).


Closes #10.