### PR TITLE
HackageDistro: fix formatting of csv package data to not use raw Show strings

### DIFF
--- a/src/Curator/HackageDistro.hs
+++ b/src/Curator/HackageDistro.hs
@@ -5,6 +5,7 @@ module Curator.HackageDistro
 
 import Curator.Types
 import Data.ByteString.Builder (toLazyByteString)
+import Distribution.Types.PackageName
 import Network.HTTP.Client
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Pantry
@@ -58,10 +59,8 @@ uploadDistro name packages username password manager = do
         $ map go
         $ Map.toList packages
     go (name', version) =
-        "\"" <>
-        displayShow name' <>
-        "\",\"" <>
-        displayShow version <>
-        "\",\"https://www.stackage.org/package/" <>
-        displayShow name' <>
-        "\""
+       displayShow (unPackageName name') <>
+        "," <>
+        displayShow (versionString version) <>
+        "," <>
+        displayShow ("https://www.stackage.org/package/" <> unPackageName name')


### PR DESCRIPTION
Fixes #8 

This was causing the csv data look like this:
```
\"PackageName \"AC-Angle\"\",\"mkVersion [1,0]\",\"https://www.stackage.org/package/PackageName \"AC-Angle\"\"
\"PackageName \"ALUT\"\",...
:
:
```