### PR TITLE
uploadDocs: use the 'aws s3 cp' --only-show-errors option

### DIFF
--- a/src/Curator/UploadDocs.hs
+++ b/src/Curator/UploadDocs.hs
@@ -47,6 +47,7 @@ uploadDocs input' name bucket = do
       "aws"
       [ "s3"
       , "cp"
+      , "--only-show-errors"
       , "--recursive"
       , "--acl"
       , "public-read"


### PR DESCRIPTION
The s3 upload output firehose isn't terribly useful/informative other than to emphasize the uploading is happening.
So let's try to suppress it and see how that works for us.