### PR TITLE
try --no-dump-logs to quieten curator builds

### DIFF
--- a/app-curator/Main.hs
+++ b/app-curator/Main.hs
@@ -230,7 +230,7 @@ build jobs = do
   logInfo "Building"
   withWorkingDir unpackDir $ proc
     "stack"
-    (words $ "--terminal --system-ghc build --test --bench --test-suite-timeout=600 --no-rerun-tests --no-run-benchmarks --haddock --no-interleaved-output --jobs=" ++ show jobs)
+    (words $ "--terminal build --test --bench --test-suite-timeout=600 --no-rerun-tests --no-run-benchmarks --haddock --no-dump-logs --no-interleaved-output --jobs=" ++ show jobs)
     runProcess_
 
 hackageDistro :: Target -> RIO PantryApp ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.11
+resolver: lts-21.12
 
 # For local dev
 # - ../pantry


### PR DESCRIPTION
This is an attempt to fix #31

Dunno if there is an easy way to test this first in stackage before merging?
Tell me if this looks right or not, anyway

Though I guess we can always revert in the worst case...