### PR TITLE
bump fpco/pid1 to 20.04

### DIFF
--- a/.github/workflows/Dockerfile.base-build
+++ b/.github/workflows/Dockerfile.base-build
@@ -1,4 +1,4 @@
-FROM fpco/pid1:18.04
+FROM fpco/pid1:20.04
 
 ENV LANG C.UTF-8
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.github/workflows/Dockerfile.base-run
+++ b/.github/workflows/Dockerfile.base-run
@@ -1,4 +1,4 @@
-FROM fpco/pid1:18.04
+FROM fpco/pid1:20.04
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \


### PR DESCRIPTION
See if this helps with stack ghc install [failure](https://github.com/commercialhaskell/curator/actions/runs/6219384864/job/16877361030)

I am poking in the dark here a bit: not sure why stack failed to install ghc-9.4.7,
but possibly ubuntu:18.04 is too old??