### PR TITLE
HF handover patches

### DIFF
--- a/app-casa-curator/Main.hs
+++ b/app-casa-curator/Main.hs
@@ -444,7 +444,11 @@ downloadHackagePackage continuousConfig count (i, (hackageCabalId, rpli)) = do
                threadDelay (1000 * 1000)
                attempt
              StatusCodeException r _
-               | getResponseStatusCode r == 403 -> logit e
+               -- FIXME: Ignoring 500s from Hackage because of
+               -- https://github.com/haskell/hackage-server/issues/1023
+               -- Also not sure about 403s. They seem suspicious. 410s seem
+               -- legit, though.
+               | getResponseStatusCode r `elem` [403, 410, 500] -> logit e
              _ -> throwM e)
 
 -- | Record that we've populated pantry with a snapshot.

--- a/src/Curator/Constants.hs
+++ b/src/Curator/Constants.hs
@@ -3,7 +3,6 @@ module Curator.Constants
     , constraintsFilename
     , snapshotsRepo
     , constraintsRepo
-    , haddockBucket
     ) where
 
 import RIO (Text, fromString)
@@ -19,6 +18,3 @@ snapshotsRepo = "commercialhaskell/stackage-snapshots"
 
 constraintsRepo :: String
 constraintsRepo = "commercialhaskell/stackage-constraints"
-
-haddockBucket :: Text
-haddockBucket = fromString "haddock.stackage.org"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,6 @@
 resolver: lts-21.25
+nix:
+  packages: [ pkg-config libz ]
 
 # For local dev
 # - ../pantry


### PR DESCRIPTION
These are some changes that came up while working on the handover.

The change to casa-curator is already running in production. :) The change to curator is not.

To use the new bucket name option, we'll need to coordinate changes to the curation automation with changes to another component (stackage-server-cron) so that curator starts writing to the new bucket at the same time that stackage-server-cron starts reading content from there. I'll follow up with that somewhere else. This PR just enables the option in the first place.