### PR TITLE
add CURATOR_AWS_OPTIONS

### DIFF
--- a/curator.cabal
+++ b/curator.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -57,7 +57,7 @@ executable casa-curator
       TypeOperators
   ghc-options: -optP-Wno-nonportable-include-path -threaded
   build-depends:
-      aeson
+      aeson <2.2
     , base >=4.10 && <5
     , bytestring
     , casa-client

--- a/package.yaml
+++ b/package.yaml
@@ -56,7 +56,8 @@ executables:
       - text
       - optparse-simple
       - containers
-      - aeson
+      # aeson 2.2 needs attoparsec-aeson
+      - aeson < 2.2
       - http-conduit
       - syb
       - persistent-sqlite


### PR DESCRIPTION
This allows setting/changing eg `CURATOR_AWS_OPTIONS="--quiet"` etc for docs uploading without having to rebuild curator.