### PR TITLE
remove package override logic to unbreak ghc-9.10 (Cabal-3.12)

### DIFF
--- a/.github/workflows/Dockerfile.base-build
+++ b/.github/workflows/Dockerfile.base-build
@@ -1,4 +1,4 @@
-FROM fpco/pid1:20.04
+FROM fpco/pid1:22.04
 
 ENV LANG C.UTF-8
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.github/workflows/Dockerfile.base-run
+++ b/.github/workflows/Dockerfile.base-run
@@ -1,4 +1,4 @@
-FROM fpco/pid1:20.04
+FROM fpco/pid1:22.04
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \

--- a/curator.cabal
+++ b/curator.cabal
@@ -57,7 +57,8 @@ executable casa-curator
       TypeOperators
   ghc-options: -optP-Wno-nonportable-include-path -threaded
   build-depends:
-      aeson <2.2
+      aeson
+    , attoparsec-aeson
     , base >=4.10 && <5
     , bytestring
     , casa-client

--- a/package.yaml
+++ b/package.yaml
@@ -56,8 +56,8 @@ executables:
       - text
       - optparse-simple
       - containers
-      # aeson 2.2 needs attoparsec-aeson
-      - aeson < 2.2
+      - aeson
+      - attoparsec-aeson
       - http-conduit
       - syb
       - persistent-sqlite

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.25
+resolver: lts-22.43
 nix:
   packages: [ pkg-config libz ]
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: a81fb3877c4f9031e1325eb3935122e608d80715dc16b586eb11ddbff8671ecd
-    size: 640086
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/25.yaml
-  original: lts-21.25
+    sha256: 08bd13ce621b41a8f5e51456b38d5b46d7783ce114a50ab604d6bbab0d002146
+    size: 720271
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/43.yaml
+  original: lts-22.43


### PR DESCRIPTION
I believe this code is unused or unnecessary since we don't allow override ghc core libraries.

But I guess we will have to test in production first... ;-)

fixes #48 